### PR TITLE
Updates to time input handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ enriched = enrich(client, latitudes, longitudes, OutputType.LOCAL)
 converted = convert(client, latitudes, longitudes, utc_times, OutputType.LOCAL)
 
 # Classify time of day
-time_classifications = time_of_day(client, latitudes, longitudes, utc_times)
+local_times = ['2025-06-09T21:58:01.010457+01:00', '2025-06-09T19:58:01.010457-01:00', '2025-06-09T20:58:01.010457+00:00']
+time_classifications = time_of_day(client, latitudes, longitudes, local_times)
 ```
 
 ## Documentation

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -84,10 +84,10 @@ Use the ``time_of_day`` function to classify times into descriptive periods:
    # Define coordinates and times
    latitudes = [50.0088, 39.437, 66.0557]
    longitudes = [8.2756, -31.542, -23.7033]
-   utc_times = ['2024-10-19T09:18:42.542819', '2024-10-19T15:30:00.000000', '2024-10-19T21:45:15.123456']
+   local_times = ['2025-06-09T21:58:01.010457+01:00', '2025-06-09T19:58:01.010457-01:00', '2025-06-09T20:58:01.010457+00:00']
 
    # Get time of day classifications
-   classifications = time_of_day(client, latitudes, longitudes, utc_times)
+   classifications = time_of_day(client, latitudes, longitudes, local_times)
    print(classifications)  # e.g., ['morning', 'afternoon', 'night']
 
 Batch Processing

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -17,12 +17,21 @@ class TestGeoLocalTimeService(unittest.TestCase):
         self.client: GeoRapidClient = EnvironmentClientFactory.create_client_with_host(host)
         self.latitudes = [50.0088, 39.437, 66.0557, 71.0201, 39.6466, 37.0969, 70.4]
         self.longitudes = [8.2756, -31.542, -23.7033, 26.1334, 44.8109, 13.9381, -47.1]
-        self.utc_times = len(self.latitudes) * ['2024-10-19T09:18:42.542819']
+        self.utc_times = ['2024-10-19T09:18:42.542819', '2024-10-19T15:30:00.000000', '2024-10-19T21:45:15.123456']
 
     def test_enrich(self):
         result = enrich(self.client, self.latitudes, self.longitudes, OutputType.LOCAL)
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), len(self.latitudes))
+
+        # Test direct enrichment to DTC
+        # TODO: Service throws bad request error, needs investigation
+        """
+        dtc_result = enrich(self.client, self.latitudes, self.longitudes, OutputType.DTC)
+        self.assertIsInstance(dtc_result, list)
+        self.assertEqual(len(dtc_result), len(self.latitudes))
+        self.assertTrue(all(isinstance(item, str) for item in dtc_result))
+        """
 
     def test_convert(self):
         result = convert(self.client, self.latitudes, self.longitudes, self.utc_times, OutputType.LOCAL)


### PR DESCRIPTION
This pull request updates the handling of time inputs across the codebase and documentation by replacing UTC times with local times and includes a minor addition to a test case. The changes aim to improve clarity and consistency in time-related operations.

### Updates to time input handling:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R58): Updated the example to use `local_times` instead of `utc_times` when calling the `time_of_day` function, ensuring the function processes local times directly.
* [`docs/source/usage.rst`](diffhunk://#diff-66e28562c85a1bb96f431f2dd52bbabab914359e4b06f58eb1e18eadc01f5c06L87-R90): Replaced `utc_times` with `local_times` in the usage example for the `time_of_day` function, aligning the documentation with the updated behavior.

### Test case enhancements:

* [`tests/test_services.py`](diffhunk://#diff-caee650c3003842e9277d696a063ab724d42606e64cbf44cf1deb9d1d67d1d98L20-R35): Updated the `setUp` method to use a diverse set of `utc_times` instead of repeating a single value. Additionally, added a commented-out test case for direct enrichment to DTC (Date-Time Classification), with a note indicating a known issue requiring investigation.