### PR TITLE
Fixed the bug in the service for direct day of time conversions

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -24,14 +24,11 @@ class TestGeoLocalTimeService(unittest.TestCase):
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), len(self.latitudes))
 
-        # Test direct enrichment to DTC
-        # TODO: Service throws bad request error, needs investigation
-        """
+        # Test direct enrichment to DTC        
         dtc_result = enrich(self.client, self.latitudes, self.longitudes, OutputType.DTC)
         self.assertIsInstance(dtc_result, list)
         self.assertEqual(len(dtc_result), len(self.latitudes))
         self.assertTrue(all(isinstance(item, str) for item in dtc_result))
-        """
 
     def test_convert(self):
         result = convert(self.client, self.latitudes, self.longitudes, self.utc_times, OutputType.LOCAL)


### PR DESCRIPTION
This pull request includes a small change to the `tests/test_services.py` file. The change re-enables a previously commented-out test for direct enrichment to DTC by removing the comment block.